### PR TITLE
[Fix] 서치 결과뷰에서 push navigation 되도록 수정, 탭바, 네비게이션바 투명도 수정

### DIFF
--- a/RoomEscape/RoomEscape/SceneDelegate.swift
+++ b/RoomEscape/RoomEscape/SceneDelegate.swift
@@ -16,10 +16,22 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         guard let _ = (scene as? UIWindowScene) else { return }
                 
-        if #available(iOS 15.0, *) {
-            let tabBarAppearance = UITabBarAppearance()
+        if #available(iOS 13.0, *) {
+            let tabBarAppearance: UITabBarAppearance = UITabBarAppearance()
             tabBarAppearance.configureWithDefaultBackground()
-            UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
+            tabBarAppearance.backgroundColor = UIColor(rgb: 0x161616)
+            UITabBar.appearance().standardAppearance = tabBarAppearance
+
+            if #available(iOS 15.0, *) {
+                UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
+            }
+        }
+        
+        if #available(iOS 15, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithTransparentBackground()
+            UINavigationBar.appearance().standardAppearance = appearance
+            UINavigationBar.appearance().scrollEdgeAppearance = appearance
         }
     }
 

--- a/RoomEscape/RoomEscape/ViewControllers/SearchResultViewController.swift
+++ b/RoomEscape/RoomEscape/ViewControllers/SearchResultViewController.swift
@@ -30,13 +30,13 @@ class SearchResultViewController: UIViewController, UITableViewDelegate {
         }
     }
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let storyboard = UIStoryboard(name: "Detail", bundle: nil)
         guard let cell = tableView.cellForRow(at: indexPath) as? RoomTableViewCell else { return }
-        guard let detailViewController = storyboard.instantiateViewController(identifier: "DetailViewControllerRef") as? DetailViewController else { return }
+        guard let detailViewController = self.storyboard?.instantiateViewController(identifier: "DetailViewControllerRef") as? DetailViewController else { return }
 
         detailViewController.roomIndex = cell.index - 1
 
-        self.present(detailViewController, animated: true)
+//        self.present(detailViewController, animated: true)
+        self.presentingViewController?.navigationController?.pushViewController(detailViewController, animated: true)
         
     }
 }

--- a/RoomEscape/RoomEscape/ViewControllers/TeamViewController.swift
+++ b/RoomEscape/RoomEscape/ViewControllers/TeamViewController.swift
@@ -307,7 +307,7 @@ extension TeamViewController: UITableViewDataSource {
             selectionCell.roomImage?.clipsToBounds = true
             
             for i in 0 ..< roomInfo.difficulty {
-                selectionCell.stars?.arrangedSubviews[i].tintColor = UIColor(named: "star");
+                selectionCell.difficulties?.arrangedSubviews[i].tintColor = UIColor(named: "star");
             }
             
             DispatchQueue.main.async {

--- a/RoomEscape/RoomEscape/Views/RoomSelectionTableViewCell.swift
+++ b/RoomEscape/RoomEscape/Views/RoomSelectionTableViewCell.swift
@@ -13,7 +13,7 @@ class RoomSelectionTableViewCell: UITableViewCell {
     @IBOutlet weak var roomName: UITextView!
     @IBOutlet weak var storeName: UILabel!
     @IBOutlet weak var genre: UILabel!
-    @IBOutlet weak var stars: UIStackView!
+    @IBOutlet weak var difficulties: UIStackView!
     @IBOutlet weak var selectionCover: UIView!
     
     override func awakeFromNib() {

--- a/RoomEscape/RoomEscape/Views/RoomSelectionTableViewCell.xib
+++ b/RoomEscape/RoomEscape/Views/RoomSelectionTableViewCell.xib
@@ -189,11 +189,11 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="difficulties" destination="juC-ke-Ddq" id="1vq-7c-vMT"/>
                 <outlet property="genre" destination="Hvr-AU-ack" id="SU0-Ax-9tP"/>
                 <outlet property="roomImage" destination="6r4-Zd-cn4" id="jgC-jk-1tt"/>
                 <outlet property="roomName" destination="b43-Do-ROD" id="Xte-UO-Tpj"/>
                 <outlet property="selectionCover" destination="LlX-OA-HxB" id="DjI-ga-4V1"/>
-                <outlet property="stars" destination="juC-ke-Ddq" id="1vq-7c-vMT"/>
                 <outlet property="storeName" destination="Toj-CV-9aP" id="oMW-Ee-z1t"/>
             </connections>
             <point key="canvasLocation" x="216.66666666666669" y="176.11607142857142"/>

--- a/RoomEscape/RoomEscape/Views/SearchResult.storyboard
+++ b/RoomEscape/RoomEscape/Views/SearchResult.storyboard
@@ -5,7 +5,6 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,20 +16,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="qYz-Ff-Rvc">
-                                <rect key="frame" x="0.0" y="104" width="414" height="758"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="syP-lP-vvn">
-                                        <rect key="frame" x="0.0" y="44.5" width="414" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="syP-lP-vvn" id="FfU-3Q-s98">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                </prototypes>
-                            </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EDa-4Z-AHV">
                                 <rect key="frame" x="30" y="44" width="354" height="60"/>
                                 <subviews>
@@ -48,17 +33,31 @@
                                     <constraint firstAttribute="height" constant="60" id="Ql7-XG-Q7U"/>
                                 </constraints>
                             </view>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="qYz-Ff-Rvc">
+                                <rect key="frame" x="18" y="104" width="378" height="758"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="syP-lP-vvn">
+                                        <rect key="frame" x="0.0" y="44.5" width="378" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="syP-lP-vvn" id="FfU-3Q-s98">
+                                            <rect key="frame" x="0.0" y="0.0" width="378" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" name="Background"/>
                         <constraints>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="EDa-4Z-AHV" secondAttribute="trailing" constant="30" id="9Jp-MT-Jhz"/>
                             <constraint firstItem="EDa-4Z-AHV" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="Moj-7X-WYE"/>
-                            <constraint firstItem="qYz-Ff-Rvc" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="csG-sv-chJ"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="qYz-Ff-Rvc" secondAttribute="trailing" constant="18" id="XMf-hX-CoJ"/>
                             <constraint firstItem="EDa-4Z-AHV" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="30" id="npR-gx-L3a"/>
                             <constraint firstItem="qYz-Ff-Rvc" firstAttribute="top" secondItem="EDa-4Z-AHV" secondAttribute="bottom" id="tu9-Rt-0sh"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="qYz-Ff-Rvc" secondAttribute="bottom" id="ukl-Ah-hRp"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="qYz-Ff-Rvc" secondAttribute="trailing" id="yp3-e8-Nqy"/>
+                            <constraint firstItem="qYz-Ff-Rvc" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="18" id="vjN-nm-LQ2"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="qfU-Sn-pqR"/>
@@ -89,8 +88,5 @@
         <namedColor name="text3">
             <color red="0.74509803921568629" green="0.74509803921568629" blue="0.74509803921568629" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>

--- a/RoomEscape/RoomEscape/Views/SearchResult.storyboard
+++ b/RoomEscape/RoomEscape/Views/SearchResult.storyboard
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="qYz-Ff-Rvc">
-                                <rect key="frame" x="0.0" y="148" width="414" height="714"/>
+                                <rect key="frame" x="0.0" y="104" width="414" height="758"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="syP-lP-vvn">
@@ -32,7 +32,7 @@
                                 </prototypes>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EDa-4Z-AHV">
-                                <rect key="frame" x="30" y="88" width="354" height="60"/>
+                                <rect key="frame" x="30" y="44" width="354" height="60"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eDJ-Ye-Up4">
                                         <rect key="frame" x="0.0" y="20" width="42" height="21"/>
@@ -80,24 +80,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4XP-PY-LQa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2631.8840579710145" y="17.410714285714285"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="kfW-vF-SB5">
-            <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="lpO-G3-xP7" sceneMemberID="viewController">
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="HkN-Kq-fuD">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <nil name="viewControllers"/>
-                    <connections>
-                        <segue destination="Y6W-OH-hqX" kind="relationship" relationship="rootViewController" id="m7P-hH-0Z4"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="tD5-bj-stc" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="942.02898550724649" y="84.375"/>
         </scene>
     </scenes>
     <resources>


### PR DESCRIPTION
## 개요

- SearchResultView 에서 DetailView 로 Push navigation 되도록 수정
- 탭바, 네비게이션 ios 15에서 발생하는 투명도 수정

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)

- [ ]  기능 추가
- [ ]  기능 삭제
- [x]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

## 주요 작업 사항

- SearchResultView 에서 DetailView 로 Push navigation 되도록 수정
- 탭바, 네비게이션 ios 15에서 발생하는 투명도 수정


https://user-images.githubusercontent.com/56063805/182009414-7f3963a7-566b-4655-92a7-15cfc470337b.mp4

![Simulator Screen Shot - iPhone 13 - 2022-07-31 at 12 55 46](https://user-images.githubusercontent.com/56063805/182009417-03174191-d861-405d-928e-745cb21a9966.png)


## 적용 파일

- SearchResult.storyboard
- SearchResultViewController.swift
- SceneDelegate.swift